### PR TITLE
Add missing dependency - django-multiselectfield

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=2.2,<2.3
 django-jquery
 django-bootstrap4
 django-bootstrap-datepicker-plus
+django-multiselectfield


### PR DESCRIPTION
Hi, I've just cloned the repo and after following the running steps I was receiving the following error:

```
File "/home/projects/deadlines_app/tasks/models.py", line 5, in <module>
    from multiselectfield import MultiSelectField
ModuleNotFoundError: No module named 'multiselectfield'
```

I figured it out it was due to a missing dependencie in requirements.txt

So I added it, hope it helps.

___

P.S.= This is my first PR to an external project, let me known if I'm doing something wrong