### PR TITLE
Add Travis CI config for testing and linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 /venv
 /.vscode
 .idea
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+python:
+  - 3.6
+  - 3.7
+  - 3.8
+
+install:
+  - pip install -r requirements.txt
+  - pip install codecov
+
+script:
+  - coverage run --include='./*' manage.py test
+  - coverage report -m
+
+after_success:
+  - codecov
+
+jobs:
+  include:
+    - stage: lint
+      python: 3.8
+      script:
+        - black .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # A Deadlines app
 
+[![Build Status](https://travis-ci.com/marceloFA/deadlines_app.svg?branch=master)](https://travis-ci.com/marceloFA/deadlines_app)
+[![codecov](https://codecov.io/gh/marceloFA/deadlines_app/branch/master/graph/badge.svg)](https://codecov.io/gh/marceloFA/deadlines_app)
+
 This is a small Django project to register and manage academic Deadlines
 
 Here are the current django apps that compose this project

--- a/apps/models.py
+++ b/apps/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+
 class ModelWithTimeStamp(models.Model):
     """ safely adds create_at field to any model that inherits this """
 

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -8,26 +8,21 @@ from users import views as user_views
 app_name = "apps"
 
 urlpatterns = [
-    
     # main url's
     path("admin/", admin.site.urls),
     path("events/", include("events.urls", namespace="events")),
     path("submissions/", include("submissions.urls", namespace="submissions")),
     path("", include("events.urls", namespace="home")),
-
     # Registration and SignIn related
     path("register/", user_views.register, name="register"),
     path("login/", user_views.login_request, name="login"),
     path("logout/", user_views.logout_request, name="logout"),
-
     # Profile related
     path("profile/", user_views.show_profile, name="profile"),
     path("profile/edit/<int:pk>", user_views.student_update, name="edit_profile"),
-
     # Deactivation related
     path("deactivate/", user_views.deactivate, name="deactivate"),
     path("reactivate/", user_views.reactivate, name="reactivate"),
-    
     # Password reset related
     path(
         "password_reset/", auth_views.PasswordResetView.as_view(), name="password_reset"

--- a/events/forms.py
+++ b/events/forms.py
@@ -3,10 +3,11 @@ from events.models import Event
 from users.models import Student
 from bootstrap_datepicker_plus import DatePickerInput
 
+
 class EventForm(forms.ModelForm):
     class Meta:
         model = Event
-        exclude = ("is_done", )
+        exclude = ("is_done",)
 
     name = forms.CharField(
         label="Event Name",
@@ -30,10 +31,13 @@ class EventForm(forms.ModelForm):
         required=True, label="Deadline", widget=DatePickerInput(format="%Y-%m-%d")
     )
 
-    progress_percentage =  forms.IntegerField(widget=forms.NumberInput(attrs={'min':0,'max':100,'type':'range', 'step':5}))
+    progress_percentage = forms.IntegerField(
+        widget=forms.NumberInput(
+            attrs={"min": 0, "max": 100, "type": "range", "step": 5}
+        )
+    )
 
     students = forms.ModelMultipleChoiceField(
         queryset=Student.objects.filter(is_active=True),
         widget=forms.CheckboxSelectMultiple,
     )
-

--- a/events/migrations/0001_initial.py
+++ b/events/migrations/0001_initial.py
@@ -7,24 +7,46 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='Event',
+            name="Event",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('name', models.CharField(max_length=200)),
-                ('url', models.CharField(blank=True, max_length=500, null=True)),
-                ('qualis', models.CharField(choices=[('A1', 'A1'), ('A2', 'A2'), ('B1', 'B1'), ('B2', 'B2'), ('C1', 'C1'), ('C2', 'C2'), ('C3', 'C3'), ('C4', 'C4'), ('C5', 'C5'), ('', 'Does not apply')], max_length=10)),
-                ('deadline', models.DateField()),
-                ('is_done', models.BooleanField(default=False)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("name", models.CharField(max_length=200)),
+                ("url", models.CharField(blank=True, max_length=500, null=True)),
+                (
+                    "qualis",
+                    models.CharField(
+                        choices=[
+                            ("A1", "A1"),
+                            ("A2", "A2"),
+                            ("B1", "B1"),
+                            ("B2", "B2"),
+                            ("C1", "C1"),
+                            ("C2", "C2"),
+                            ("C3", "C3"),
+                            ("C4", "C4"),
+                            ("C5", "C5"),
+                            ("", "Does not apply"),
+                        ],
+                        max_length=10,
+                    ),
+                ),
+                ("deadline", models.DateField()),
+                ("is_done", models.BooleanField(default=False)),
             ],
-            options={
-                'abstract': False,
-            },
-        ),
+            options={"abstract": False},
+        )
     ]

--- a/events/migrations/0002_event_students.py
+++ b/events/migrations/0002_event_students.py
@@ -10,13 +10,13 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('events', '0001_initial'),
+        ("events", "0001_initial"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='event',
-            name='students',
+            model_name="event",
+            name="students",
             field=models.ManyToManyField(blank=True, to=settings.AUTH_USER_MODEL),
-        ),
+        )
     ]

--- a/events/migrations/0003_event_progress_percentage.py
+++ b/events/migrations/0003_event_progress_percentage.py
@@ -5,15 +5,13 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('events', '0002_event_students'),
-    ]
+    dependencies = [("events", "0002_event_students")]
 
     operations = [
         migrations.AddField(
-            model_name='event',
-            name='progress_percentage',
+            model_name="event",
+            name="progress_percentage",
             field=models.IntegerField(default=0),
             preserve_default=False,
-        ),
+        )
     ]

--- a/events/models.py
+++ b/events/models.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.conf import settings
 from users.models import Student
 
+
 class Event(ModelWithTimeStamp):
     """ The Event model saves informations about a event, including its deadline """
 
@@ -21,11 +22,7 @@ class Event(ModelWithTimeStamp):
         ("", "Does not apply"),
     )
 
-    STATUS_CHOICES = (
-        ("1", "Enable"),
-        ("2", "Canceled"),
-        ("3", "Done"),
-    )
+    STATUS_CHOICES = (("1", "Enable"), ("2", "Canceled"), ("3", "Done"))
 
     name = models.CharField(max_length=200)
     url = models.CharField(max_length=500, null=True, blank=True)

--- a/events/views.py
+++ b/events/views.py
@@ -81,9 +81,10 @@ def event_done(request, pk):
         event = get_object_or_404(Event, pk=pk)
     else:
         event = get_object_or_404(Event, pk=pk, students=request.user)
-    event.is_done =  True
+    event.is_done = True
     event.save()
     return redirect(f"/events/{pk}")
+
 
 @login_required
 def event_undone(request, pk):
@@ -91,7 +92,7 @@ def event_undone(request, pk):
         event = get_object_or_404(Event, pk=pk)
     else:
         event = get_object_or_404(Event, pk=pk, students=request.user)
-    event.is_done =  False
+    event.is_done = False
     event.save()
     return redirect(f"/events/{pk}")
 
@@ -104,19 +105,23 @@ def filter_events(events):
     This method filter Event instances in two categories
     current events and past event, depending on the days_left field
      """
-    current_events = list(filter(lambda t: (t.days_left >= 0 and not t.is_done), events))
+    current_events = list(
+        filter(lambda t: (t.days_left >= 0 and not t.is_done), events)
+    )
     past_events = list(filter(lambda t: (t.days_left < 0 or t.is_done), events))
 
     return current_events, past_events
 
+
 def get_context(event):
-    '''
+    """
     Some context is required for each Event
-    '''
+    """
     event.days_left = get_days_left(event.deadline)
-    #event.progress_percentage = get_progress_percentage(event) # not necessary anymore as its a builtin model field now
+    # event.progress_percentage = get_progress_percentage(event) # not necessary anymore as its a builtin model field now
     event.progress_background = get_progress_background(event.progress_percentage)
     return event
+
 
 def get_days_left(deadline):
     """ Used to calculate how many days are left until a event deadline """
@@ -124,8 +129,9 @@ def get_days_left(deadline):
     days_left = (deadline - now).days
     return days_left
 
+
 # Old method of getting progress percentage, not used anymore
-#def get_progress_percentage(event):
+# def get_progress_percentage(event):
 #    """ Return the percentage of time left for a certain event based on its deadline date """
 #    created_at_date = event.created_at.date()
 #    total_days = (event.deadline - created_at_date).days

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,16 @@ attrs==19.2.0
 beautifulsoup4==4.8.0
 black==19.3b0
 Click==7.0
+coverage==4.5.4
 Django==2.2.6
 django-bootstrap-datepicker-plus==3.0.5
 django-bootstrap4==1.0.1
+django-extensions==2.2.5
 django-jquery==3.1.0
 django-mathfilters==0.4.0
 django-multiselectfield==0.1.9
 pytz==2019.2
+six==1.12.0
 soupsieve==1.9.4
 sqlparse==0.3.0
 toml==0.10.0
-django-extensions

--- a/submissions/forms.py
+++ b/submissions/forms.py
@@ -11,21 +11,24 @@ class SubmissionForm(forms.ModelForm):
 
     # The event that got a submission
     event = forms.ModelChoiceField(
-        label='What event is associated with this submission (Neither is an option)',
-        queryset=Event.objects.all()
-        )
+        label="What event is associated with this submission (Neither is an option)",
+        queryset=Event.objects.all(),
+    )
 
     # Students associated with this submission
     students = forms.ModelMultipleChoiceField(
-        label='Select the students associated with this submission',
+        label="Select the students associated with this submission",
         queryset=Student.objects.filter(is_active=True),
         widget=forms.CheckboxSelectMultiple,
     )
 
-    # Submission status 
+    # Submission status
     status = forms.CharField(
-        label="Submission status", widget=forms.Select(choices=Submission.STATUS_CHOICES)
+        label="Submission status",
+        widget=forms.Select(choices=Submission.STATUS_CHOICES),
     )
 
     # Paper url
-    paper_url = forms.CharField(required=False, widget=forms.TextInput(attrs={'class': 'special'}))
+    paper_url = forms.CharField(
+        required=False, widget=forms.TextInput(attrs={"class": "special"})
+    )

--- a/submissions/migrations/0001_initial.py
+++ b/submissions/migrations/0001_initial.py
@@ -8,23 +8,48 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-        ('events', '0001_initial'),
-    ]
+    dependencies = [("events", "0001_initial")]
 
     operations = [
         migrations.CreateModel(
-            name='Submission',
+            name="Submission",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('updated_at', models.DateTimeField(auto_now=True)),
-                ('status', models.CharField(choices=[('0', 'In Writting Process'), ('1', 'Not yet defined'), ('2', 'Pending'), ('3', 'Under Revision'), ('4', 'Accepted'), ('5', 'Rejected')], default='0', max_length=2)),
-                ('paper_url', models.CharField(blank=True, max_length=300, null=True)),
-                ('event', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, to='events.Event')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("0", "In Writting Process"),
+                            ("1", "Not yet defined"),
+                            ("2", "Pending"),
+                            ("3", "Under Revision"),
+                            ("4", "Accepted"),
+                            ("5", "Rejected"),
+                        ],
+                        default="0",
+                        max_length=2,
+                    ),
+                ),
+                ("paper_url", models.CharField(blank=True, max_length=300, null=True)),
+                (
+                    "event",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="events.Event",
+                    ),
+                ),
             ],
-            options={
-                'abstract': False,
-            },
-        ),
+            options={"abstract": False},
+        )
     ]

--- a/submissions/migrations/0002_submission_students.py
+++ b/submissions/migrations/0002_submission_students.py
@@ -10,13 +10,13 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('submissions', '0001_initial'),
+        ("submissions", "0001_initial"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='submission',
-            name='students',
+            model_name="submission",
+            name="students",
             field=models.ManyToManyField(to=settings.AUTH_USER_MODEL),
-        ),
+        )
     ]

--- a/submissions/migrations/0003_auto_20191010_2211.py
+++ b/submissions/migrations/0003_auto_20191010_2211.py
@@ -6,14 +6,17 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('submissions', '0002_submission_students'),
-    ]
+    dependencies = [("submissions", "0002_submission_students")]
 
     operations = [
         migrations.AlterField(
-            model_name='submission',
-            name='event',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='submission', to='events.Event'),
-        ),
+            model_name="submission",
+            name="event",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="submission",
+                to="events.Event",
+            ),
+        )
     ]

--- a/submissions/migrations/0004_auto_20191010_2219.py
+++ b/submissions/migrations/0004_auto_20191010_2219.py
@@ -6,14 +6,16 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('submissions', '0003_auto_20191010_2211'),
-    ]
+    dependencies = [("submissions", "0003_auto_20191010_2211")]
 
     operations = [
         migrations.AlterField(
-            model_name='submission',
-            name='event',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, to='events.Event'),
-        ),
+            model_name="submission",
+            name="event",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to="events.Event",
+            ),
+        )
     ]

--- a/submissions/models.py
+++ b/submissions/models.py
@@ -3,15 +3,16 @@ from users.models import Student
 from events.models import Event
 from apps.models import ModelWithTimeStamp
 
+
 class Submission(ModelWithTimeStamp):
-    ''' This model stores informations about academic event submissions '''
-    
+    """ This model stores informations about academic event submissions """
+
     students = models.ManyToManyField(Student, blank=False)
 
-    event = models.ForeignKey(Event, on_delete=models.SET_NULL,  null=True)
+    event = models.ForeignKey(Event, on_delete=models.SET_NULL, null=True)
 
     STATUS_CHOICES = (
-        ('0', "In Writting Process"),
+        ("0", "In Writting Process"),
         ("1", "Not yet defined"),
         ("2", "Pending"),
         ("3", "Under Revision"),
@@ -19,6 +20,6 @@ class Submission(ModelWithTimeStamp):
         ("5", "Rejected"),
     )
 
-    status = models.CharField(max_length=2, choices=STATUS_CHOICES, default='0')
+    status = models.CharField(max_length=2, choices=STATUS_CHOICES, default="0")
 
     paper_url = models.CharField(max_length=300, blank=True, null=True)

--- a/submissions/views.py
+++ b/submissions/views.py
@@ -9,7 +9,6 @@ from submissions.forms import SubmissionForm
 from users.models import Student
 
 
-
 def submission_detail(request, pk, template_name="submissions/submission_detail.html"):
 
     try:
@@ -19,17 +18,13 @@ def submission_detail(request, pk, template_name="submissions/submission_detail.
 
     submission.status_background = get_status_background(submission.status)
 
-    context = {
-        'submission': submission,
-        "students": submission.students.all(),
-    }
+    context = {"submission": submission, "students": submission.students.all()}
 
     return render(request, template_name, context)
 
 
-
 def submission_list(request, template_name="submissions/submission_list.html"):
-    
+
     submissions = Submission.objects.all()
     n_submitted, approval_rate = get_statistics()
 
@@ -37,9 +32,9 @@ def submission_list(request, template_name="submissions/submission_list.html"):
         sub.status_background = get_status_background(sub.status)
 
     context = {
-        'submissions':submissions,
-        'total_submissions':n_submitted,
-        'approval_rate': approval_rate,
+        "submissions": submissions,
+        "total_submissions": n_submitted,
+        "approval_rate": approval_rate,
     }
 
     return render(request, template_name, context)
@@ -48,7 +43,7 @@ def submission_list(request, template_name="submissions/submission_list.html"):
 @login_required
 def submission_create(request, template_name="submissions/submission_form.html"):
     form = SubmissionForm(request.POST or None)
-    
+
     if request.POST:
         if form.is_valid():
             submission = form.save(commit=False)
@@ -61,8 +56,8 @@ def submission_create(request, template_name="submissions/submission_form.html")
 
             return redirect("submissions:submission_list")
         else:
-                for msg in form._errors:
-                    messages.error(request, f"{form._errors[msg]}")
+            for msg in form._errors:
+                messages.error(request, f"{form._errors[msg]}")
 
     return render(request, template_name, {"form": form})
 
@@ -88,12 +83,14 @@ def submission_update(request, pk, template_name="submissions/submission_form.ht
 
 
 @login_required
-def submission_delete(request, pk, template_name="submissions/submission_confirm_delete.html"):
+def submission_delete(
+    request, pk, template_name="submissions/submission_confirm_delete.html"
+):
     if request.user.is_superuser:
         submission = get_object_or_404(Submission, pk=pk)
     else:
         submission = get_object_or_404(Submission, pk=pk)
-    
+
     if request.method == "POST":
         submission.delete()
         delete_message = "Successfully deleted that submission ;)"
@@ -104,13 +101,12 @@ def submission_delete(request, pk, template_name="submissions/submission_confirm
     return render(request, template_name, {"submission": submission})
 
 
-
 def get_statistics():
-    n_submitted = Submission.objects.filter(status__in=[3,4,5]).count()
+    n_submitted = Submission.objects.filter(status__in=[3, 4, 5]).count()
     n_approved = Submission.objects.filter(status=4).count()
     approval_rate = 0
     if n_submitted > 0:
-        approval_rate =  n_approved // n_submitted *100
+        approval_rate = n_approved // n_submitted * 100
     return n_submitted, approval_rate
 
 
@@ -128,7 +124,7 @@ def get_status_background(status):
         color = "warning"
     elif status == 4:
         color = "success"
-    elif status ==5:
+    elif status == 5:
         color = "danger"
     else:
         color = "light"

--- a/users/forms.py
+++ b/users/forms.py
@@ -20,13 +20,13 @@ class StudentCreationForm(UserCreationForm):
         ),
     )
 
-    def clean(self): 
-        name = self.cleaned_data.get('name') 
-        username = self.cleaned_data.get('username') 
+    def clean(self):
+        name = self.cleaned_data.get("name")
+        username = self.cleaned_data.get("username")
 
-        if len(str(name).split(" ")) != 2:  
-            self.add_error('name', 'Fill only first and last name here')
-        return self.cleaned_data 
+        if len(str(name).split(" ")) != 2:
+            self.add_error("name", "Fill only first and last name here")
+        return self.cleaned_data
 
 
 class StudentChangeForm(UserChangeForm):
@@ -51,11 +51,7 @@ class AccountDeactivationForm(forms.Form):
     password = forms.CharField(
         label="Password",
         widget=forms.PasswordInput(
-            attrs={
-                "id": "password",
-                "class": "form-control",
-                "placeholder": "Password",
-            }
+            attrs={"id": "password", "class": "form-control", "placeholder": "Password"}
         ),
     )
 
@@ -64,21 +60,13 @@ class ReactivationForm(forms.Form):
     username = forms.CharField(
         label="Username",
         widget=forms.TextInput(
-            attrs={
-                "id": "username",
-                "class": "form-control",
-                "placeholder": "Username",
-            }
+            attrs={"id": "username", "class": "form-control", "placeholder": "Username"}
         ),
     )
 
     password = forms.CharField(
         label="Password",
         widget=forms.PasswordInput(
-            attrs={
-                "id": "password",
-                "class": "form-control",
-                "placeholder": "Password",
-            }
+            attrs={"id": "password", "class": "form-control", "placeholder": "Password"}
         ),
     )

--- a/users/migrations/0001_initial.py
+++ b/users/migrations/0001_initial.py
@@ -10,36 +10,113 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-        ('auth', '0011_update_proxy_permissions'),
-    ]
+    dependencies = [("auth", "0011_update_proxy_permissions")]
 
     operations = [
         migrations.CreateModel(
-            name='Student',
+            name="Student",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('password', models.CharField(max_length=128, verbose_name='password')),
-                ('last_login', models.DateTimeField(blank=True, null=True, verbose_name='last login')),
-                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
-                ('username', models.CharField(error_messages={'unique': 'A user with that username already exists.'}, help_text='Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.', max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()], verbose_name='username')),
-                ('first_name', models.CharField(blank=True, max_length=30, verbose_name='first name')),
-                ('last_name', models.CharField(blank=True, max_length=150, verbose_name='last name')),
-                ('email', models.EmailField(blank=True, max_length=254, verbose_name='email address')),
-                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
-                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
-                ('name', models.CharField(max_length=100)),
-                ('is_active', models.BooleanField(default=True)),
-                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', related_name='user_set', related_query_name='user', to='auth.Group', verbose_name='groups')),
-                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', related_query_name='user', to='auth.Permission', verbose_name='user permissions')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("password", models.CharField(max_length=128, verbose_name="password")),
+                (
+                    "last_login",
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name="last login"
+                    ),
+                ),
+                (
+                    "is_superuser",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates that this user has all permissions without explicitly assigning them.",
+                        verbose_name="superuser status",
+                    ),
+                ),
+                (
+                    "username",
+                    models.CharField(
+                        error_messages={
+                            "unique": "A user with that username already exists."
+                        },
+                        help_text="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                        max_length=150,
+                        unique=True,
+                        validators=[
+                            django.contrib.auth.validators.UnicodeUsernameValidator()
+                        ],
+                        verbose_name="username",
+                    ),
+                ),
+                (
+                    "first_name",
+                    models.CharField(
+                        blank=True, max_length=30, verbose_name="first name"
+                    ),
+                ),
+                (
+                    "last_name",
+                    models.CharField(
+                        blank=True, max_length=150, verbose_name="last name"
+                    ),
+                ),
+                (
+                    "email",
+                    models.EmailField(
+                        blank=True, max_length=254, verbose_name="email address"
+                    ),
+                ),
+                (
+                    "is_staff",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates whether the user can log into this admin site.",
+                        verbose_name="staff status",
+                    ),
+                ),
+                (
+                    "date_joined",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now, verbose_name="date joined"
+                    ),
+                ),
+                ("name", models.CharField(max_length=100)),
+                ("is_active", models.BooleanField(default=True)),
+                (
+                    "groups",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="The groups this user belongs to. A user will get all permissions granted to each of their groups.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.Group",
+                        verbose_name="groups",
+                    ),
+                ),
+                (
+                    "user_permissions",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="Specific permissions for this user.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.Permission",
+                        verbose_name="user permissions",
+                    ),
+                ),
             ],
             options={
-                'verbose_name': 'user',
-                'verbose_name_plural': 'users',
-                'abstract': False,
+                "verbose_name": "user",
+                "verbose_name_plural": "users",
+                "abstract": False,
             },
-            managers=[
-                ('objects', django.contrib.auth.models.UserManager()),
-            ],
-        ),
+            managers=[("objects", django.contrib.auth.models.UserManager())],
+        )
     ]

--- a/users/tests.py
+++ b/users/tests.py
@@ -66,7 +66,7 @@ class StudentRegister(TestCase):
 
     def test_register_student_success(self):
         register_data = {
-            "name": "a",
+            "name": "a name",
             "username": "a",
             "password1": "password",
             "password2": "password",

--- a/users/views.py
+++ b/users/views.py
@@ -6,8 +6,12 @@ from django.contrib.auth.hashers import check_password
 from django.contrib.auth.decorators import login_required
 
 # Custom imports
-from users.forms import StudentCreationForm, StudentChangeForm, AccountDeactivationForm, \
-    ReactivationForm
+from users.forms import (
+    StudentCreationForm,
+    StudentChangeForm,
+    AccountDeactivationForm,
+    ReactivationForm,
+)
 from .models import Student
 from events.models import Event
 from events.views import get_context
@@ -134,9 +138,11 @@ def show_profile(request):
     events = Event.objects.filter(students=request.user.id)
     # get context
     events = [get_context(t) for t in events]
-    
-    context = {"events": events,
-                "submissions": Submission.objects.filter(students=request.user.id)}
+
+    context = {
+        "events": events,
+        "submissions": Submission.objects.filter(students=request.user.id),
+    }
     return render(request, "profile.html", context)
 
 


### PR DESCRIPTION
With this config, the project is tested on [Travis CI](https://travis-ci.com) with Python 3.6, 3.7, and 3.8 on every push. It will also check for code coverage and upload the result to [codecov](https://codecov.io). Badges for the Travis build and code coverage will appear on `README.md`.

You'll need to:
1. Sign in to Travis CI and Codecov
2. Add the repository to your account on both sites.
3. Copy the token from Codecov and paste it to Travis CI settings for your repo as `CODECOV_TOKEN`

Normally, step 3 shouldn't be required for public repositories, but [Travis CI for public projects is moving from travis-ci.org to travis-ci.com](https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/) and it seems that Codecov hasn't picked up on that, so you have to set the token as if it's a private repository.

Hopefully, this can help to alert regressions such as [this commit](https://github.com/marceloFA/deadlines_app/commit/eb19560c0a094bbb970009de52493e99e087320b) that fails [this test](https://github.com/marceloFA/deadlines_app/blob/master/users/tests.py#L69).

To add prevention locally, I can add a pre-commit [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) using [pre-commit](https://pre-commit.com) so that `black .` and `python manage.py test` is run before every commit. However, this would add another dependency and creating the first commit after this change would need an internet connection. If you're okay with that, I'd be happy to create another PR.